### PR TITLE
Introduce Pagination support for Get-CbcAlert

### DIFF
--- a/src/PSCarbonBlackCloud.Format.ps1xml
+++ b/src/PSCarbonBlackCloud.Format.ps1xml
@@ -99,13 +99,13 @@
             <Alignment>Left</Alignment>
           </TableColumnHeader>
           <TableColumnHeader>
-            <Label>First Event</Label>
-            <Width>15</Width>
+            <Label>First Event Time </Label>
+            <Width>20</Width>
             <Alignment>Left</Alignment>
           </TableColumnHeader>
           <TableColumnHeader>
-            <Label>Last Event</Label>
-            <Width>15</Width>
+            <Label>Last Event Time</Label>
+            <Width>20</Width>
             <Alignment>Left</Alignment>
           </TableColumnHeader>
         </TableHeaders>
@@ -129,10 +129,10 @@
                 <PropertyName>DeviceId</PropertyName>
               </TableColumnItem>
               <TableColumnItem>
-                <PropertyName>FirstEvent</PropertyName>
+                <PropertyName>FirstEventTime</PropertyName>
               </TableColumnItem>
               <TableColumnItem>
-                <PropertyName>LastEvent</PropertyName>
+                <PropertyName>LastEventTime</PropertyName>
               </TableColumnItem>
             </TableColumnItems>
           </TableRowEntry>

--- a/src/Private/Invoke-CbcRequest.ps1
+++ b/src/Private/Invoke-CbcRequest.ps1
@@ -1,6 +1,7 @@
 using module ../PSCarbonBlackCloud.Classes.psm1
 function Invoke-CbcRequest {
 	[CmdletBinding()]
+	#[OutputType([BasicHtmlWebResponseObject])]
 	param(
 		[Parameter(Mandatory = $true,Position = 0)]
 		[ValidateNotNullOrEmpty()]
@@ -33,10 +34,10 @@ function Invoke-CbcRequest {
 		$FormattedUri = $Endpoint -f $Params
 
 		$FullUri = $Server.Uri + $FormattedUri
-		Write-Debug "[$($MyInvocation.MyCommand.Name)] requesting: ${FullUri}"
-		Write-Debug "[$($MyInvocation.MyCommand.Name)] with request body: ${Body}"
-		Write-Debug "[$($MyInvocation.MyCommand.Name)] with method body: ${Method}"
-		Write-Debug "[$($MyInvocation.MyCommand.Name)] with uri params body: ${Params}"
+		Write-Debug "[$($MyInvocation.MyCommand.Name)] requesting: $(FullUri)"
+		Write-Debug "[$($MyInvocation.MyCommand.Name)] with request body: $($Body)"
+		Write-Debug "[$($MyInvocation.MyCommand.Name)] with method body: $(Method)"
+		Write-Debug "[$($MyInvocation.MyCommand.Name)] with uri params body: $(Params)"
 		try {
 			$Request = Invoke-WebRequest -Uri $FullUri -Headers $Headers -Method $Method -Body $Body
 			Write-Debug "[$($MyInvocation.MyCommand.Name)] got response with content: $($Request.Content)"

--- a/src/Private/Invoke-PagedCbcRequest.ps1
+++ b/src/Private/Invoke-PagedCbcRequest.ps1
@@ -1,0 +1,85 @@
+using module ../PSCarbonBlackCloud.Classes.psm1
+function Invoke-PagedCbcRequest {
+	[CmdletBinding()]
+	#[OutputType([BasicHtmlWebResponseObject[]])]
+	param(
+		[Parameter(Mandatory = $true,Position = 0)]
+		[ValidateNotNullOrEmpty()]
+		[CbcServer]$Server,
+
+		[Parameter(Mandatory = $true,Position = 1)]
+		[ValidateNotNullOrEmpty()]
+		[string]$Endpoint,
+
+		[Parameter(Mandatory = $true,Position = 2)]
+		[string]$Method,
+
+		[array]$Params,
+
+		[hashtable]$Body,
+
+		#The limit of the API Server request
+		[int]$ApiResultLimit = 10000,
+
+		#The client side max results request
+		[int]$MaxResults = 50,
+
+		[int]$StartIterator = 0 
+
+	)
+
+	begin {
+		Write-Verbose "[$($MyInvocation.MyCommand.Name)] function started"
+	}
+
+	process {
+		
+		if ($null -eq $Body.sort) {
+			Write-Debug " There is no sorting criteria defined in the request body. Results might not be complete"
+		}
+		
+		$TotalResultCount = 0
+		$Body.rows = $ApiResultLimit
+		
+		
+		Do {
+			<#
+			Test for a corner case where we've reached the desired count of objects,
+			but the returned results in the last iteration was -eq to the $ApiResultLimit
+			Would happen when $MaxResults % $ApiResultLimit -eq 0
+			#>
+			if ($MaxResults -eq $TotalResultCount) {
+				return
+			}
+			#Test if remaining to retrieve are less than what we can retrieve with one api call
+			if ($MaxResults - $TotalResultCount -lt $ApiResultLimit) {
+				
+				#If true, retrieve remaining only 
+				$Body.rows = $MaxResults - $TotalResultCount
+				
+			}
+			$Body.start = $StartIterator
+			$convertedBody = $Body | ConvertTo-Json
+			$Response = Invoke-CbcRequest -Endpoint $global:CBC_CONFIG.endpoints["Alerts"]["Search"] `
+				-Method $Method `
+				-Server $Server `
+				-Body $convertedBody
+
+			$JsonContent = $Response.Content | ConvertFrom-Json
+			
+			#JsonContent.results.count is the count of the returned objects
+			Write-Debug "JsonContent.results.count is: $($JsonContent.results.count)"
+			Write-Debug "TotalResultCount is $TotalResultCount"
+			$TotalResultCount += $JsonContent.results.count
+			$StartIterator += $JsonContent.results.count
+
+			#Returning the response without exiting the loop, no return statement
+			$Response
+
+		} While (-Not ($JsonContent.results.count -lt $ApiResultLimit) )
+	}
+
+	end {
+		Write-Verbose "[$($MyInvocation.MyCommand.Name)] function finished"
+	}
+}


### PR DESCRIPTION
-Add Invoke-PagedCbcRequest.ps1 utility
-Fix minor CbcAlert issue
-Unify debug logging in Invoke-CbcRequest.ps1

Testing done: 
Total available alerts on the test env 539
1. Set ApiResultLimit to 100 in Invoke-PagedCbcRequest
Get-CbcAlert -MaxResults 500
Get-CbcAlert -MaxResults 501
Get-CbcAlert -MaxResults  100
Get-CbcAlert -MaxResults 51
Get-CbcAlert -MaxResults 10 

2. Set ApiResultLimit to 10000 in Invoke-PagedCbcRequest
Get-CbcAlert
Get-CbcAlert -MaxResults 15000
Get-CbcAlert -MaxResults 51