### PR TITLE
Documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Now we can start using the cmdlets.
 
 
 ```powershell
-PS > Connect-CbcServer -CbcServer "http://cbcserver.cbc" -Org "MyOrg" -Token "MyToken"
+PS > Connect-CbcServer -Server "http://cbcserver.cbc" -Org "OrgKey" -Token "MyToken"
 ```
 
 ## Development


### PR DESCRIPTION
The usage guide's example commandline uses "-CbcServer," while the commandlet expects "-Server." Also, some undocumented API calls use Org ID instead of Org Key, so changing that disambiguates the parameter. 